### PR TITLE
Make Bark a HF Pre-Trained Model

### DIFF
--- a/bark/model_fine.py
+++ b/bark/model_fine.py
@@ -79,7 +79,6 @@ class FineGPT(GPT):
     def __init__(self, config):
         super().__init__(config)
         del self.lm_head
-        self.config = config
         self.n_codes_total = config.n_codes_total
         self.transformer = nn.ModuleDict(
             dict(
@@ -127,21 +126,6 @@ class FineGPT(GPT):
         x = self.transformer.ln_f(x)
         logits = self.lm_heads[pred_idx - self.config.n_codes_given](x)
         return logits
-
-    def get_num_params(self, non_embedding=True):
-        """
-        Return the number of parameters in the model.
-        For non-embedding count (default), the position embeddings get subtracted.
-        The token embeddings would too, except due to the parameter sharing these
-        params are actually used as weights in the final layer, so we include them.
-        """
-        n_params = sum(p.numel() for p in self.parameters())
-        if non_embedding:
-            for wte in self.transformer.wtes:
-                n_params -= wte.weight.numel()
-            n_params -= self.transformer.wpe.weight.numel()
-        return n_params
-
 
 @dataclass
 class FineGPTConfig(GPTConfig):


### PR DESCRIPTION
PR to make the Bark model a HF `PreTrainedModel`. The `PreTrainedModel` class takes care of all loading / saving logic, enabling checkpoints to be downloaded / pushed directly to the HF Hub:

```python
from bark import GPT

model = GPT.from_pretrained("suno/bark-text")  # load model weights from Hub
```

Model weights on the HF Hub have version control and download counters. Users can also filter HF Hub models by type, e.g. [by TTS](https://huggingface.co/models?pipeline_tag=text-to-speech&sort=downloads).

Preliminarily, this PR only makes the required modelling code changes. The next step of the PR is to update [`generation.py`](https://github.com/suno-ai/bark/blob/main/bark/generation.py), namely replacing the `_load_model` functionality with a single `.from_pretrained` call:
https://github.com/suno-ai/bark/blob/d621ee3088f29f6d12c2d8b0503e2368f18fabd9/bark/generation.py#L169

Since Transformers is already a dependency of Bark, this adds no new dependency requirements. It also has no effect on the `.forward` call (functionality remains 1-to-1 the same).

For details on the `PreTrainedModel` class, refer to the [code](https://github.com/huggingface/transformers/blob/abbc96a2148da0c91fa078bd021984b2cc10ef85/src/transformers/modeling_utils.py#L1031) and [docs](https://huggingface.co/docs/transformers/v4.28.1/en/main_classes/model#transformers.PreTrainedModel).