### PR TITLE
Allow consistency and deterministic generations

### DIFF
--- a/bark/__init__.py
+++ b/bark/__init__.py
@@ -1,2 +1,2 @@
-from .api import generate_audio, text_to_semantic, semantic_to_waveform, save_as_prompt
+from .api import generate_audio, text_to_semantic, semantic_to_waveform, save_as_prompt, set_seed
 from .generation import SAMPLE_RATE, preload_models

--- a/bark/api.py
+++ b/bark/api.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
 import numpy as np
+import torch
+import random
+import os
 
 from .generation import codec_decode, generate_coarse, generate_fine, generate_text_semantic
 
@@ -81,6 +84,48 @@ def save_as_prompt(filepath, full_generation):
     assert("coarse_prompt" in full_generation)
     assert("fine_prompt" in full_generation)
     np.savez(filepath, **full_generation)
+
+
+def set_seed(seed: int = 0):
+    """Set the seed
+
+    seed = 0         Generate a random seed
+    seed = -1        Disable deterministic algorithms
+    0 < seed < 2**32 Set the seed
+
+    Args:
+        seed: integer to use as seed
+
+    Returns:
+        integer used as seed
+    """
+
+    original_seed = seed
+
+    # See for more informations: https://pytorch.org/docs/stable/notes/randomness.html
+    if seed == -1:
+        # Disable deterministic
+        torch.backends.cudnn.deterministic = False
+        torch.backends.cudnn.benchmark = True
+    else:
+        # Enable deterministic
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    if seed <= 0:
+        # Generate random seed
+        # Use default_rng() because it is independent of np.random.seed()
+        seed = np.random.default_rng().integers(1, 2**32 - 1)
+
+    assert(0 < seed and seed < 2**32)
+
+    np.random.seed(seed)
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+
+    return original_seed if original_seed != 0 else seed
 
 
 def generate_audio(


### PR DESCRIPTION
This PR moves the process of loading the history prompt to a function to avoid duplication and now accepts the full generation returned by the `generate_audio()`, this allows to achieve consistency between generations as the example bellow:

```python
from bark import SAMPLE_RATE, generate_audio, preload_models
from scipy.io.wavfile import write as write_wav
import numpy as np

preload_models()

prompts = [
    "Hello, my name is Suno. And, uh — and I like pizza. [laughs]",
    "But I also have other interests such as playing tic tac toe.",
    "Buenos días Miguel. Tu colega piensa que tu alemán es extremadamente malo.",
    "But I suppose your english isn't terrible.",
]

audio_arrays = []
history_prompt = None

for idx, prompt in enumerate(prompts):
    full_generation, audio_array = generate_audio(prompt, history_prompt=history_prompt, output_full=True)
    if idx == 0:
        history_prompt = full_generation
    audio_arrays.append(audio_array)

combined_audio = np.concatenate(audio_arrays)
write_wav("/path/to/audio.wav", SAMPLE_RATE, combined_audio)
"""
```

Also, this PR adds the `set_seed(seed)` to allow deterministic generations:
* Use `seed = set_seed()` or `seed = set_seed(0)` to generate and set a random seed, the seed is returned.
* Use `set_seed(seed)` to set a specific seed number.
* Use `set_seed(-1)` to disable the deterministic process and go back to fully non-deterministic.

### BE AWARE: the seed affects torch, numpy and python, so if you are running other softwares that require non-deterministic random values, remember to call `set_seed(-1)` after you generate the audio.

Example:

```python
from bark import SAMPLE_RATE, generate_audio, preload_models, set_seed
from scipy.io.wavfile import write as write_wav
import numpy as np

preload_models()

prompt = "I have a silky smooth voice, and today I will tell you about the exercise regimen of the common sloth."

set_seed(123)
audio_array_1 = generate_audio(prompt)
write_wav("/path/to/audio_1.wav", SAMPLE_RATE, audio_array_1)

set_seed(123)
audio_array_2 = generate_audio(prompt)
write_wav("/path/to/audio_2.wav", SAMPLE_RATE, audio_array_2)

# BE AWARE: the seed affects torch, numpy and python,
# so if you are running other softwares that require non-deterministic random values,
# remember to call `set_seed(-1)` after you generate the audio.
set_seed(-1)

assert(np.array_equal(audio_array_1, audio_array_2))
"""
```
