### PR TITLE
Whitelist speaker files that have no language associated with them

### DIFF
--- a/bark/generation.py
+++ b/bark/generation.py
@@ -74,6 +74,8 @@ for _, lang in SUPPORTED_LANGS:
     for n in range(10):
         ALLOWED_PROMPTS.add(f"{lang}_speaker_{n}")
 
+for n in range(10):
+    ALLOWED_PROMPTS.add(f"speaker_{n}")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This enables the use of speaker_0-9.npz files that currently get blocked.
If they should be blocked then they could be deleted.