### PR TITLE
Add support to download models from Hugging Face Hub

### DIFF
--- a/bark/generation.py
+++ b/bark/generation.py
@@ -165,9 +165,8 @@ def _grab_best_device(use_gpu=True):
 def _download(from_hf_path, file_name, to_local_path):
     os.makedirs(CACHE_DIR, exist_ok=True)
     destination_file_name = to_local_path.split("/")[-1]
-    file_dir = CACHE_DIR
-    hf_hub_download(repo_id=from_hf_path, filename=file_name, local_dir=file_dir)
-    os.replace(f"{CACHE_DIR}/{file_name}", to_local_path)
+    hf_hub_download(repo_id=from_hf_path, filename=file_name, local_dir=CACHE_DIR)
+    os.replace(os.path.join(CACHE_DIR, file_name), to_local_path)
 
 class InferenceContext:
     def __init__(self, benchmark=False):

--- a/bark/generation.py
+++ b/bark/generation.py
@@ -93,17 +93,17 @@ OFFLOAD_CPU = os.environ.get("SUNO_OFFLOAD_CPU", False)
 
 REMOTE_MODEL_PATHS = {
     "text_small": {
-        "repo_id": "reach-vb/bark-small",
+        "repo_id": "reach-vb/bark",
         "file_name": "text.pt",
         "checksum": "b3e42bcbab23b688355cd44128c4cdd3",
     },
     "coarse_small": {
-        "repo_id": "reach-vb/bark-small",
+        "repo_id": "reach-vb/bark",
         "file_name": "coarse.pt",
         "checksum": "5fe964825e3b0321f9d5f3857b89194d",
     },
     "fine_small": {
-        "repo_id": "reach-vb/bark-small",
+        "repo_id": "reach-vb/bark",
         "file_name": "fine.pt",
         "checksum": "5428d1befe05be2ba32195496e58dc90",
     },

--- a/bark/generation.py
+++ b/bark/generation.py
@@ -90,7 +90,7 @@ USE_SMALL_MODELS = os.environ.get("SUNO_USE_SMALL_MODELS", False)
 GLOBAL_ENABLE_MPS = os.environ.get("SUNO_ENABLE_MPS", False)
 OFFLOAD_CPU = os.environ.get("SUNO_OFFLOAD_CPU", False)
 
-# REMOTE_BASE_URL = "https://dl.suno-models.io/bark/models/v0/"
+REMOTE_BASE_URL = "https://dl.suno-models.io/bark/models/v0/"
 
 # REMOTE_MODEL_PATHS = {
 #     "text_small": {
@@ -176,7 +176,7 @@ def _md5(fname):
 
 def _get_ckpt_path(model_type, use_small=False):
     model_key = f"{model_type}_small" if use_small or USE_SMALL_MODELS else model_type
-    model_name = _string_md5(REMOTE_MODEL_PATHS[model_key]["path"])
+    model_name = _string_md5(REMOTE_MODEL_PATHS[model_key]["file_name"])
     return os.path.join(CACHE_DIR, f"{model_name}.pt")
 
 

--- a/bark/generation.py
+++ b/bark/generation.py
@@ -162,15 +162,6 @@ def _grab_best_device(use_gpu=True):
     return device
 
 
-S3_BUCKET_PATH_RE = r"s3\:\/\/(.+?)\/"
-
-
-def _parse_s3_filepath(s3_filepath):
-    bucket_name = re.search(S3_BUCKET_PATH_RE, s3_filepath).group(1)
-    rel_s3_filepath = re.sub(S3_BUCKET_PATH_RE, "", s3_filepath)
-    return bucket_name, rel_s3_filepath
-
-
 def _download(from_hf_path, file_name, to_local_path):
     os.makedirs(CACHE_DIR, exist_ok=True)
     destination_file_name = to_local_path.split("/")[-1]

--- a/bark/generation.py
+++ b/bark/generation.py
@@ -90,34 +90,6 @@ USE_SMALL_MODELS = os.environ.get("SUNO_USE_SMALL_MODELS", False)
 GLOBAL_ENABLE_MPS = os.environ.get("SUNO_ENABLE_MPS", False)
 OFFLOAD_CPU = os.environ.get("SUNO_OFFLOAD_CPU", False)
 
-REMOTE_BASE_URL = "https://dl.suno-models.io/bark/models/v0/"
-
-# REMOTE_MODEL_PATHS = {
-#     "text_small": {
-#         "path": os.path.join(REMOTE_BASE_URL, "text.pt"),
-#         "checksum": "b3e42bcbab23b688355cd44128c4cdd3",
-#     },
-#     "coarse_small": {
-#         "path": os.path.join(REMOTE_BASE_URL, "coarse.pt"),
-#         "checksum": "5fe964825e3b0321f9d5f3857b89194d",
-#     },
-#     "fine_small": {
-#         "path": os.path.join(REMOTE_BASE_URL, "fine.pt"),
-#         "checksum": "5428d1befe05be2ba32195496e58dc90",
-#     },
-#     "text": {
-#         "path": os.path.join(REMOTE_BASE_URL, "text_2.pt"),
-#         "checksum": "54afa89d65e318d4f5f80e8e8799026a",
-#     },
-#     "coarse": {
-#         "path": os.path.join(REMOTE_BASE_URL, "coarse_2.pt"),
-#         "checksum": "8a98094e5e3a255a5c9c0ab7efe8fd28",
-#     },
-#     "fine": {
-#         "path": os.path.join(REMOTE_BASE_URL, "fine_2.pt"),
-#         "checksum": "59d184ed44e3650774a2f0503a48a97b",
-#     },
-# }
 
 REMOTE_MODEL_PATHS = {
     "text_small": {

--- a/bark/generation.py
+++ b/bark/generation.py
@@ -93,32 +93,32 @@ OFFLOAD_CPU = os.environ.get("SUNO_OFFLOAD_CPU", False)
 
 REMOTE_MODEL_PATHS = {
     "text_small": {
-        "repo_id": "reach-vb/bark",
+        "repo_id": "suno/bark",
         "file_name": "text.pt",
         "checksum": "b3e42bcbab23b688355cd44128c4cdd3",
     },
     "coarse_small": {
-        "repo_id": "reach-vb/bark",
+        "repo_id": "suno/bark",
         "file_name": "coarse.pt",
         "checksum": "5fe964825e3b0321f9d5f3857b89194d",
     },
     "fine_small": {
-        "repo_id": "reach-vb/bark",
+        "repo_id": "suno/bark",
         "file_name": "fine.pt",
         "checksum": "5428d1befe05be2ba32195496e58dc90",
     },
     "text": {
-        "repo_id": "reach-vb/bark",
+        "repo_id": "suno/bark",
         "file_name": "text_2.pt",
         "checksum": "54afa89d65e318d4f5f80e8e8799026a",
     },
     "coarse": {
-        "repo_id": "reach-vb/bark",
+        "repo_id": "suno/bark",
         "file_name": "coarse_2.pt",
         "checksum": "8a98094e5e3a255a5c9c0ab7efe8fd28",
     },
     "fine": {
-        "repo_id": "reach-vb/bark",
+        "repo_id": "suno/bark",
         "file_name": "fine_2.pt",
         "checksum": "59d184ed44e3650774a2f0503a48a97b",
     },

--- a/bark/generation.py
+++ b/bark/generation.py
@@ -146,7 +146,7 @@ REMOTE_MODEL_PATHS = {
         "checksum": "8a98094e5e3a255a5c9c0ab7efe8fd28",
     },
     "fine": {
-        "repo_id": "reach-vb/bark-small",
+        "repo_id": "reach-vb/bark",
         "file_name": "fine_2.pt",
         "checksum": "59d184ed44e3650774a2f0503a48a97b",
     },
@@ -199,24 +199,12 @@ def _parse_s3_filepath(s3_filepath):
     return bucket_name, rel_s3_filepath
 
 
-# def _download(from_s3_path, to_local_path):
-#     os.makedirs(CACHE_DIR, exist_ok=True)
-#     response = requests.get(from_s3_path, stream=True)
-#     total_size_in_bytes = int(response.headers.get("content-length", 0))
-#     block_size = 1024
-#     progress_bar = tqdm.tqdm(total=total_size_in_bytes, unit="iB", unit_scale=True)
-#     with open(to_local_path, "wb") as file:
-#         for data in response.iter_content(block_size):
-#             progress_bar.update(len(data))
-#             file.write(data)
-#     progress_bar.close()
-#     if total_size_in_bytes != 0 and progress_bar.n != total_size_in_bytes:
-#         raise ValueError("ERROR, something went wrong")
-
-
 def _download(from_hf_path, file_name, to_local_path):
     os.makedirs(CACHE_DIR, exist_ok=True)
-    hf_hub_download(repo_id=from_hf_path, filename=file_name, cache_dir=to_local_path)
+    destination_file_name = to_local_path.split("/")[-1]
+    file_dir = CACHE_DIR
+    hf_hub_download(repo_id=from_hf_path, filename=file_name, local_dir=file_dir)
+    os.replace(f"{CACHE_DIR}/{file_name}", to_local_path)
 
 class InferenceContext:
     def __init__(self, benchmark=False):


### PR DESCRIPTION
Hi @gkucsko - Just a spin-off from https://github.com/suno-ai/bark/pull/4, the models are available under my namespace on the hugging face hub but we can decide on the best way possible. Could also be just one repo on the hub. Let me know what you think.

The change should, by and large, have no major impact (old users would have to reload the model weights once more).

There are a couple of pros for this approach:
1. We can release new versions of the models on the same repo without having to change anything in the code.
2. Via the hugging face hub library we can ensure that the models are downloaded in a more fault-resistant way.
3. Caching works out of the box with this approach.
4. Of course, since the models are on the hub it leads to better discovery.

Let me know if this is okay for you.

cc: @Wauplin to review from HF Hub side.

