### PR TITLE
Update `pyproject.toml` to include v2 assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dev = [
 packages = ["bark"]
 
 [tool.setuptools.package-data]
-bark = ["assets/prompts/*.npz"]
+bark = ["assets/prompts/*.npz", "assets/prompts/v2/*.npz"]
+
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
When installing bark from `main` one will not get the new v2 assets as they're not included as package data. This PR updates `pyproject.toml` to include the v2 .npz assets as setup tools package_data. 