### PR TITLE
Fix clean_models

### DIFF
--- a/bark/generation.py
+++ b/bark/generation.py
@@ -184,7 +184,7 @@ def _clear_cuda_cache():
 
 def clean_models(model_key=None):
     global models
-    model_keys = [model_key] if model_key is not None else models.keys()
+    model_keys = [model_key] if model_key is not None else list(models.keys())
     for k in model_keys:
         if k in models:
             del models[k]


### PR DESCRIPTION
By copying the model keys before looping through them, you will fix `RuntimeError: dictionary changed size during iteration`, which currently occurs when deleting all models.

original, with an explanation of the problem (comments for explanation of the problem)
```python
def clean_models(model_key=None):
    global models
    model_keys = [model_key] if model_key is not None else models.keys()  #<-- sets model_keys to a reference of model.keys() if model_key is None
    for k in model_keys:  #<-- loops through model_keys, which is model.keys() when model_key is None
        if k in models:
            del models[k]  #<-- deletes key "k" from models, resizing model.keys(), but model_keys holds a reference to model.keys()
    _clear_cuda_cache()
    gc.collect()
```

and my solution
```python
def clean_models(model_key=None):
    global models
    model_keys = [model_key] if model_key is not None else list(models.keys())  #<-- we copy the model keys so we can loop through the copy while deleting keys from the "true/canonical" keys.
    for k in model_keys:
        if k in models:
            del models[k]
    _clear_cuda_cache()
    gc.collect()
```

It's a simple solution for a problem that has been bugging me a lot, as I was unable to unload bark.