### PR TITLE
docs: environ snippet should use quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ If you are interested, you can sign up for early access [here](https://3os84zs17
 
 ```python
 import os
-os.environ["SUNO_OFFLOAD_CPU"] = True
-os.environ["SUNO_USE_SMALL_MODELS"] = True
+os.environ["SUNO_OFFLOAD_CPU"] = "True"
+os.environ["SUNO_USE_SMALL_MODELS"] = "True"
 ```
 
 #### My generated audio sounds like a 1980s phone call. What's happening?


### PR DESCRIPTION
This is a documentation only PR which fixes the snippet for using small models.

os.environ takes `str` and not `bool` or any other type. So fix the docs to use quotes.