### PR TITLE
fix: perf: use sdpa if dropout > 0 on fine model

### DIFF
--- a/bark/model_fine.py
+++ b/bark/model_fine.py
@@ -26,9 +26,9 @@ class NonCausalSelfAttention(nn.Module):
         self.n_head = config.n_head
         self.n_embd = config.n_embd
         self.dropout = config.dropout
-        # flash attention make GPU go brrrrr but support is only in PyTorch nightly and still a bit scary
+        # flash attention make GPU go brrrrr but support is only in PyTorch >= 2.0
         self.flash = (
-            hasattr(torch.nn.functional, "scaled_dot_product_attention") and self.dropout == 0.0
+            hasattr(torch.nn.functional, "scaled_dot_product_attention")
         )
 
     def forward(self, x):


### PR DESCRIPTION
scaled dot product attention works fine if there is a dropout since PyTorch 2.0.

This patch simply removes the (outdated) check if dropout > 0 and turns on flash attention if it is available in torch. The patch seems to be applied to the regular model but not the fine model.

on a H100 it seems to result in a 10%-20% speedup.