### PR TITLE
perf: disable kvcache for semantic by default

### DIFF
--- a/bark/api.py
+++ b/bark/api.py
@@ -27,7 +27,7 @@ def text_to_semantic(
         history_prompt=history_prompt,
         temp=temp,
         silent=silent,
-        use_kv_caching=True
+        use_kv_caching=False
     )
     return x_semantic
 


### PR DESCRIPTION
An analysis of my previous patches suggests that use_kv_caching=True is not a win at all for the text model.

The current KV caching code has quite a bit of overhead. In particular, it (re)allocates large tensors with adding to the cache via a `torch.cat` call. With the coarse model it seems to result in some performance gain, but it is definitely not a win for the smaller text model. It seems that the KV cache was what was causing the bimodality in #366, I'm guessing sometimes we would get unlucky and the model would have to reallocate.

With this change I can consistently get about 280 it/second performance for the text model on an H100 after warmup.
