### PR TITLE
[Fix] Fix cli optional type check

### DIFF
--- a/bark/cli.py
+++ b/bark/cli.py
@@ -20,9 +20,9 @@ def cli():
     parser.add_argument("--output_dir", type=str, default=".", help="directory to save the outputs")
     parser.add_argument(
         "--history_prompt",
-        type=Optional[Union[Dict, str]],
+        type=str,
         default=None,
-        help="history choice for audio cloning",
+        help="history choice for audio cloning, be path to the .npz file.",
     )
     parser.add_argument(
         "--text_temp",
@@ -48,7 +48,7 @@ def cli():
     input_text: str = args.get("text")
     output_filename: str = args.get("output_filename")
     output_dir: str = args.get("output_dir")
-    history_prompt: Optional[Union[Dict, str]] = args.get("history_prompt")
+    history_prompt: str = args.get("history_prompt")
     text_temp: float = args.get("text_temp")
     waveform_temp: float = args.get("waveform_temp")
     silent: bool = args.get("silent")


### PR DESCRIPTION
Addressing the bug reported in #339.

It is caused by sth weird about the python parser type checks for Union...Using a string file path is much safer and a stable input. 


-----
Tested:
```
python -m bark --text "大家好，这里是测试" --history_prompt "bark/assets/prompts/zh_speaker_1.npz"
```
Can confirm the audio output is good. 
