### PR TITLE
Enable MPS (if available) by default on Mac

### DIFF
--- a/bark/generation.py
+++ b/bark/generation.py
@@ -90,7 +90,7 @@ def _cast_bool_env_var(s):
 
 
 USE_SMALL_MODELS = _cast_bool_env_var(os.environ.get("SUNO_USE_SMALL_MODELS", "False"))
-GLOBAL_ENABLE_MPS = _cast_bool_env_var(os.environ.get("SUNO_ENABLE_MPS", "False"))
+GLOBAL_ENABLE_MPS = _cast_bool_env_var(os.environ.get("SUNO_ENABLE_MPS", "True"))
 OFFLOAD_CPU = _cast_bool_env_var(os.environ.get("SUNO_OFFLOAD_CPU", "False"))
 
 


### PR DESCRIPTION
MPS significantly speeds up performance. This PR would enable it by default if it is available. This allow inference without having to manually enable MPS.