### PR TITLE
Fixed bark examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](https://dcbadge.vercel.app/api/server/J2B2vsjKuE?style=flat&compact=True)](https://suno.ai/discord)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/FM.svg?style=social&label=@suno_ai_)](https://twitter.com/suno_ai_)
 
-> 🔗 [Examples](https://suno.ai/examples/bark-v0) • [Suno Studio Waitlist](https://suno-ai.typeform.com/suno-studio) • [Updates](#-updates) • [How to Use](#-usage-in-python) • [Installation](#-installation) • [FAQ](#-faq)
+> 🔗 [Examples](https://suno.ai/examples/bark) • [Suno Studio Waitlist](https://suno-ai.typeform.com/suno-studio) • [Updates](#-updates) • [How to Use](#-usage-in-python) • [Installation](#-installation) • [FAQ](#-faq)
 
 [//]: <br> (vertical spaces around image)
 <br>


### PR DESCRIPTION
The link was wrong, there's 404 at https://www.suno.ai/examples/bark-v0.

Also note that there's 404 at https://www.suno.ai/examples/chirp-v1, and there's no such page publicly available on https://suno-ai.notion.site/Suno-Examples-de4aa9eddc6d4a22a23d45ee286223e9. Probably you just forgot to share it