### PR TITLE
Fix model loading in recent versions of PyTorch.

### DIFF
--- a/bark/generation.py
+++ b/bark/generation.py
@@ -209,7 +209,7 @@ def _load_model(ckpt_path, device, use_small=False, model_type="text"):
     if not os.path.exists(ckpt_path):
         logger.info(f"{model_type} model not found, downloading into `{CACHE_DIR}`.")
         _download(model_info["repo_id"], model_info["file_name"])
-    checkpoint = torch.load(ckpt_path, map_location=device)
+    checkpoint = torch.load(ckpt_path, weights_only=False, map_location=device)
     # this is a hack
     model_args = checkpoint["model_args"]
     if "input_vocab_size" not in model_args:


### PR DESCRIPTION
Trying to run bark in a recent version of PyTorch (>= 2.6) fails because the models need to load also the model architecture:
```bash
Traceback (most recent call last):
  File "/Users/fdb/Source/bark/example_glitch.py", line 156, in <module>
    preload_models()
  File "/Users/fdb/Source/bark/bark/generation.py", line 318, in preload_models
    _ = load_model(
        ^^^^^^^^^^^
  File "/Users/fdb/Source/bark/bark/generation.py", line 275, in load_model
    model = _load_model_f(ckpt_path, device)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fdb/Source/bark/bark/generation.py", line 212, in _load_model
    checkpoint = torch.load(ckpt_path, weights_only=True, map_location=device)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fdb/Source/bark/.venv/lib/python3.11/site-packages/torch/serialization.py", line 1529, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray.scalar was not an allowed global by default. Please use `torch.serialization.add_safe_globals([numpy.core.multiarray.scalar])` or the `torch.serialization.safe_globals([numpy.core.multiarray.scalar])` context manager to allowlist this global if you trust this class/function.
```

This PR sets `weights_only` to `False` so the models can be loaded correctly.