### PR TITLE
fix: add weights_only=False for PyTorch 2.6+ compatibility

### DIFF
--- a/bark/generation.py
+++ b/bark/generation.py
@@ -209,7 +209,9 @@ def _load_model(ckpt_path, device, use_small=False, model_type="text"):
     if not os.path.exists(ckpt_path):
         logger.info(f"{model_type} model not found, downloading into `{CACHE_DIR}`.")
         _download(model_info["repo_id"], model_info["file_name"])
-    checkpoint = torch.load(ckpt_path, map_location=device)
+    # weights_only=False is required for PyTorch 2.6+ where default changed to True
+    # The checkpoints contain numpy arrays which require pickle to load
+    checkpoint = torch.load(ckpt_path, map_location=device, weights_only=False)
     # this is a hack
     model_args = checkpoint["model_args"]
     if "input_vocab_size" not in model_args:


### PR DESCRIPTION
## Summary
Fix checkpoint loading crash on PyTorch 2.6+ due to `weights_only` default change.

## Problem
PyTorch 2.6 changed `torch.load()` default from `weights_only=False` to `weights_only=True`. The Bark checkpoints contain numpy arrays (`numpy.core.multiarray.scalar`) that require pickle to load, causing:

```
UnpicklingError: Weights only load failed...
```

Users cannot work around this from outside Bark's code since `torch.serialization.add_safe_globals()` and `safe_globals` context manager don't apply to internal `torch.load` calls.

## Solution
Explicitly set `weights_only=False` in the `torch.load()` call. This restores the previous behavior and maintains backward compatibility with older PyTorch versions.

**Note:** Since the checkpoints are downloaded from official Hugging Face repos (controlled by the Bark team), allowing pickle is safe. The `weights_only` restriction is meant for untrusted checkpoints.

Fixes #656