### PR TITLE
fix: disable dropout during inference in scaled_dot_product_attention

### DIFF
--- a/bark/model.py
+++ b/bark/model.py
@@ -77,7 +77,8 @@ class CausalSelfAttention(nn.Module):
             else:
                 is_causal = True
 
-            y = torch.nn.functional.scaled_dot_product_attention(q, k, v, dropout_p=self.dropout, is_causal=is_causal)
+            dropout_p = self.dropout if self.training else 0.0
+            y = torch.nn.functional.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p, is_causal=is_causal)
         else:
             # manual implementation of attention
             att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))

--- a/bark/model_fine.py
+++ b/bark/model_fine.py
@@ -43,8 +43,9 @@ class NonCausalSelfAttention(nn.Module):
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
         if self.flash:
             # efficient attention using Flash Attention CUDA kernels
+            dropout_p = self.dropout if self.training else 0.0
             y = torch.nn.functional.scaled_dot_product_attention(
-                q, k, v, attn_mask=None, dropout_p=self.dropout, is_causal=False
+                q, k, v, attn_mask=None, dropout_p=dropout_p, is_causal=False
             )
         else:
             # manual implementation of attention


### PR DESCRIPTION
## Summary

- `F.scaled_dot_product_attention` was being called with `dropout_p=self.dropout` unconditionally in both `CausalSelfAttention` (`bark/model.py`) and `NonCausalSelfAttention` (`bark/model_fine.py`).
- During inference (`model.eval()`), dropout should be disabled (i.e., `dropout_p=0.0`), but the original code always passed the training dropout probability.
- This fix sets `dropout_p = self.dropout if self.training else 0.0` before calling `scaled_dot_product_attention`, ensuring dropout is only applied during training.

## Why this matters

Unlike `nn.Dropout` which automatically respects `model.eval()`, the `dropout_p` parameter in `F.scaled_dot_product_attention` is a raw float and does not check the module's training mode. Passing a non-zero dropout during inference introduces random noise into attention scores, leading to non-deterministic and degraded outputs.

## Test plan

- [x] Verify that `self.training` is `False` when the model is in eval mode (`model.eval()`)
- [x] Confirm that `F.scaled_dot_product_attention` receives `dropout_p=0.0` during inference
- [x] Confirm that `F.scaled_dot_product_attention` receives the configured dropout during training