### PR TITLE
Fix broken Examples link to point to Demos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![](https://dcbadge.vercel.app/api/server/J2B2vsjKuE?style=flat&compact=True)](https://suno.ai/discord)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/FM.svg?style=social&label=@suno_ai_)](https://twitter.com/suno_ai_)
 
-> 🔗 [Examples](https://suno.ai/examples/bark-v0) • [Suno Studio Waitlist](https://suno-ai.typeform.com/suno-studio) • [Updates](#-updates) • [How to Use](#-usage-in-python) • [Installation](#-installation) • [FAQ](#-faq)
+> 🔗 [Demos](#-demos) • [Suno Studio Waitlist](https://suno-ai.typeform.com/suno-studio) • [Updates](#-updates) • [How to Use](#-usage-in-python) • [Installation](#-installation) • [FAQ](#-faq)
 
 [//]: <br> (vertical spaces around image)
 <br>


### PR DESCRIPTION
The previous `Examples` link (`https://suno.ai/examples/bark-v0`) redirects to the Suno homepage and no longer provides Bark examples.

This PR updates the navigation link to point to the internal 🎧 Demos section (`#-demos`) in the README for a stable and relevant reference.

Related to #642